### PR TITLE
Collapsed comments, probationary status and more

### DIFF
--- a/R/LIHKGr.R
+++ b/R/LIHKGr.R
@@ -27,10 +27,9 @@ library(rvest)
     Sys.sleep(sample(seq(3, 5, by=0.001), 1))
     collapsed <- remote_driver$findElements("xpath", "//div[@class='_1d3Z5jQRq3WnuIm0hnMh0c']")
     if (length(collapsed)) { # click collapsed comments if any
-      for (x in collapsed) {
-        x$clickElement()
-        Sys.sleep(sample(seq(3, 5, by=0.001), 1))
-      }
+        for (x in collapsed) {
+            x$clickElement()
+        }
     }
     html <- remote_driver$getPageSource()
     if(grepl("recaptcha_widget", html[[1]])){
@@ -38,7 +37,7 @@ library(rvest)
     }
     pg <-  read_html(html[[1]])
     if (length(collapsed)) { # remove any additional page accidentally loaded when clicking collapsed comments
-      xml_remove(xml_find_all(pg, "//div[@class='_3jxQCFWg9LDtkSkIVLzQ8L']")[-1])
+        xml_remove(xml_find_all(pg, "//div[@class='_3jxQCFWg9LDtkSkIVLzQ8L']")[-1])
     }
     return(pg)
 }
@@ -58,10 +57,10 @@ library(rvest)
         html_attr('href')
     ##get_probation
     probation <- html %>% html_nodes("._36ZEkSvpdj_igmog0nluzh") %>%
-    html_node("div div small ._10ZVxePYNpBeLjzkQ88wtj") %>%
-    html_text() %>%
-    is.na() %>%
-    not()
+        html_node("div div small ._10ZVxePYNpBeLjzkQ88wtj") %>%
+        html_text() %>%
+        is.na() %>%
+        not()
     ##get_text
     text <- html %>% html_nodes("._36ZEkSvpdj_igmog0nluzh") %>%
         html_node("div div .GAagiRXJU88Nul1M7Ai0H ._2cNsJna0_hV8tdMj3X6_gJ") %>%

--- a/R/LIHKGr.R
+++ b/R/LIHKGr.R
@@ -25,6 +25,14 @@ library(rvest)
 .crack_it <- function(url, remote_driver){
     remote_driver$navigate(url)
     Sys.sleep(sample(seq(3, 5, by=0.001), 1))
+    # Click collapsed comments
+    collapsed <- remote_driver$findElements("xpath", "//div[@class='_1d3Z5jQRq3WnuIm0hnMh0c']")
+    if (length(collapsed)) {
+      for (x in collapsed) {
+        x$clickElement()
+        Sys.sleep(sample(seq(3, 5, by=0.001), 1))
+      }
+    }
     html <- remote_driver$getPageSource()
     if(grepl("recaptcha_widget", html[[1]])){
         readline(prompt="Captcha Detected. Press [enter] to continue after solving")

--- a/R/LIHKGr.R
+++ b/R/LIHKGr.R
@@ -171,7 +171,7 @@ Lihkg_reader <- R6::R6Class(
             }
             self$scrape_alot(private$failed)
         },
-        empty = function() {
+        clear = function() {
             self$bag <- tibble::tibble()
         },
         finalize = function() {

--- a/R/LIHKGr.R
+++ b/R/LIHKGr.R
@@ -34,6 +34,7 @@ library(rvest)
     html <- remote_driver$getPageSource()
     if(grepl("recaptcha_widget", html[[1]])){
         readline(prompt="Captcha Detected. Press [enter] to continue after solving")
+        return(.crack_it(url, remote_driver)) # make sure collapsed comments are expanded
     }
     pg <-  read_html(html[[1]])
     if (length(collapsed)) { # remove any additional page accidentally loaded when clicking collapsed comments

--- a/R/LIHKGr.R
+++ b/R/LIHKGr.R
@@ -109,7 +109,7 @@ library(rvest)
             notdone <- FALSE
         } else if (titlewords == 1){
             notdone <- FALSE
-            posts <- tibble::tibble(number = "ERROR", date = "ERROR", uid = "ERROR", text = "ERROR", upvote = "ERROR", downvote = "ERROR", postid = postid, title = "Deleted Post", board = "ERROR", collection_time = Sys.time())
+            posts <- tibble::tibble(number = "ERROR", date = "ERROR", uid = "ERROR", probation = "ERROR", text = "ERROR", upvote = "ERROR", downvote = "ERROR", postid = postid, title = "Deleted Post", board = "ERROR", collection_time = Sys.time())
             print("Empty Post, Skipping")
         } else {
             print(paste0("page ", i, " (last page)"))
@@ -122,7 +122,7 @@ library(rvest)
     } # End of While Loop
     if( notdone && attempt > 4 ){
         if (titlewords == 2 && nrow(posts) > 1){
-            warning <- tibble::tibble(number = "EMPTY LAST PAGE", date = "EMPTY LAST PAGE", uid = "ERROR", text = "ERROR", upvote = "ERROR", downvote = "ERROR", postid = postid, title = "Deleted Last Page", board = "ERROR", collection_time = Sys.time())
+            warning <- tibble::tibble(number = "EMPTY LAST PAGE", date = "EMPTY LAST PAGE", uid = "ERROR", probation = "ERROR", text = "ERROR", upvote = "ERROR", downvote = "ERROR", postid = postid, title = "Deleted Last Page", board = "ERROR", collection_time = Sys.time())
             posts <- dplyr::bind_rows(posts, warning)
             print("Empty Last Page Detected")
             notdone <- FALSE

--- a/R/LIHKGr.R
+++ b/R/LIHKGr.R
@@ -56,6 +56,12 @@ library(rvest)
     uid <- html %>% html_nodes("._36ZEkSvpdj_igmog0nluzh") %>%
         html_node("div div small .ZZtOrmcIRcvdpnW09DzFk a") %>%
         html_attr('href')
+    ##get_probation
+    probation <- html %>% html_nodes("._36ZEkSvpdj_igmog0nluzh") %>%
+    html_node("div div small ._10ZVxePYNpBeLjzkQ88wtj") %>%
+    html_text() %>%
+    is.na() %>%
+    not()
     ##get_text
     text <- html %>% html_nodes("._36ZEkSvpdj_igmog0nluzh") %>%
         html_node("div div .GAagiRXJU88Nul1M7Ai0H ._2cNsJna0_hV8tdMj3X6_gJ") %>%


### PR DESCRIPTION
I made the following changes:

1. Add ability to fetch collapsed comments (those with LIHKG emoji only or short phrases like "Push")
1. Crawl the probationary status (P牌) of every user
1. Add an `clear()` method to clear `self$bag` (not sure if it's useful but it fits my workflow)
1. Minor fixes: change the class name to `lihkg_reader` and correct the error of applying `stop()` to the wrong driver in the finalizer

To fetch the collapsed comments, the modified code clicks on each of the collapsed comments to expand them before collecting the page source. I also added a recursive call of `.crack_it()` in the case of captcha to make sure that the comments are always uncollapsed before scraping. But this solution is a bit ugly since it'll reload the page one extra time. Implementing another way of detecting captcha will solve this problem (like via `findElement()`) but I don't know the structure of the captcha page. It'd be nice if you can tell me which tag the captcha widget is wrapped in so I can change the code accordingly.

Thanks for your work. Please let me know if there's anything I can help.